### PR TITLE
Fix button layout on iPad

### DIFF
--- a/Vie/View Controllers/FWLaunchScreenViewController.m
+++ b/Vie/View Controllers/FWLaunchScreenViewController.m
@@ -61,17 +61,24 @@
 {
     [super viewWillLayoutSubviews];
 
+    CGRect backgroundFrame = self.backgroundImageView.frame;
+    CGRect bounds = self.view.bounds;
+    CGFloat horizontalSpace = MIN(backgroundFrame.size.width, bounds.size.width);
+    CGFloat horizontalOffset = MAX(backgroundFrame.origin.x, bounds.origin.x);
+    CGFloat verticalSpace = MIN(backgroundFrame.size.height, bounds.size.height);
+    CGFloat bottomOfLogo = CGRectGetMaxY(self.logoImageView.frame);
+    
     [self.copyrightLabel sizeToFit];
     CGRect copyrightFrame = self.copyrightLabel.frame;
-    copyrightFrame.origin.x = FWRoundFloat((self.view.bounds.size.width - copyrightFrame.size.width) / 2.0f);
-    copyrightFrame.origin.y = self.view.bounds.size.height - copyrightFrame.size.height - 12.0f;
+    copyrightFrame.origin.x = horizontalOffset + FWRoundFloat((horizontalSpace - copyrightFrame.size.width) / 2.0f);
+    copyrightFrame.origin.y = verticalSpace - copyrightFrame.size.height - 12.0f;
     self.copyrightLabel.frame = copyrightFrame;
 
     NSArray *buttons = @[self.quickPlayButton, self.patternsButton, self.savedGamesButton, self.aboutButton];
-    CGFloat availableHeight = self.copyrightLabel.frame.origin.y - CGRectGetMaxY(self.logoImageView.frame);
+    CGFloat availableHeight = copyrightFrame.origin.y - bottomOfLogo;
     CGFloat buttonSpacing = [UIView verticalSpaceToDistributeViews:buttons inAvailableVerticalSpace:availableHeight];
     [UIView distributeVerticallyViews:buttons
-                      startingAtPoint:CGPointMake(FWRoundFloat(self.view.bounds.size.width / 2.0f), CGRectGetMaxY(self.logoImageView.frame) + buttonSpacing)
+                      startingAtPoint:CGPointMake((FWRoundFloat(horizontalSpace / 2.0f) + horizontalOffset), bottomOfLogo + buttonSpacing)
                           withSpacing:buttonSpacing];
 }
 


### PR DESCRIPTION
The green launch image doesn't fill the screen on the iPad, but the layout of the buttons and copyright are based on full screen.  This causes the copyright and about button to be put in the white background where they're invisible.  This change fixes this issue without messing up the layout on iPhone.

Original iPad Retina:
![screen shot 2017-02-27 at 11 17 50 am](https://cloud.githubusercontent.com/assets/3286918/23369208/97411dc8-fcde-11e6-8b89-75a521b7bfd6.png)

Updated iPad Retina:
![screen shot 2017-02-27 at 11 18 29 am](https://cloud.githubusercontent.com/assets/3286918/23369263/c1cf3750-fcde-11e6-8f65-033e8f03b55d.png)

iPhone 7 Plus with update:
![screen shot 2017-02-27 at 11 21 16 am](https://cloud.githubusercontent.com/assets/3286918/23369308/ecf2201e-fcde-11e6-8e58-9b9772766a1a.png)

